### PR TITLE
Priority dropdown should default to Normal

### DIFF
--- a/Knockstrap/templates/static/javascript/knockstrap.js
+++ b/Knockstrap/templates/static/javascript/knockstrap.js
@@ -320,7 +320,7 @@ var QueueModel = function(data) {
 		  name($.trim(data.filename));
 		status(data.status);
 		categoryInternal(/^\*|None$/.test(data.cat) ? "Default" : data.cat);
-		priorityInternal(data.priority || "2");
+		priorityInternal(data.priority || "0");
 		scriptInternal(data.script);
 		optionInternal(parseInt(data.unpackopts));
 		totalMB(parseFloat(data.mb));


### PR DESCRIPTION
When no priority is set on a queue item so the data value from the server is undefined, the priority dropdown currently shows "Force" rather than "Normal".
